### PR TITLE
[#5] 거래소 화면의 구조를 설계하고 Structure를 구현해요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDF2799728C008F2AD1 /* CoinListView.swift */; };
+		48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE127997298008F2AD1 /* CoinListViewModel.swift */; };
+		48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */; };
 		4881F42727979E5200472C90 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42627979E5200472C90 /* TabBarController.swift */; };
 		4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42827979E6600472C90 /* ExchangeViewController.swift */; };
 		4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42D2797A1C400472C90 /* ProductServiceViewController.swift */; };
@@ -47,6 +50,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
+		48256CE127997298008F2AD1 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
+		48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewCell.swift; sourceTree = "<group>"; };
 		4881F42627979E5200472C90 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		4881F42827979E6600472C90 /* ExchangeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewController.swift; sourceTree = "<group>"; };
 		4881F42D2797A1C400472C90 /* ProductServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductServiceViewController.swift; sourceTree = "<group>"; };
@@ -98,6 +104,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		48256CD42799715A008F2AD1 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				48256CD52799716C008F2AD1 /* CoinList */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		48256CD52799716C008F2AD1 /* CoinList */ = {
+			isa = PBXGroup;
+			children = (
+				48256CDF2799728C008F2AD1 /* CoinListView.swift */,
+				48256CE127997298008F2AD1 /* CoinListViewModel.swift */,
+				48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */,
+			);
+			path = CoinList;
+			sourceTree = "<group>";
+		};
 		4881F42327979D8B00472C90 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -121,6 +145,7 @@
 		4881F42527979DDF00472C90 /* Exchange */ = {
 			isa = PBXGroup;
 			children = (
+				48256CD42799715A008F2AD1 /* Components */,
 				4881F42827979E6600472C90 /* ExchangeViewController.swift */,
 			);
 			path = Exchange;
@@ -363,7 +388,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
+				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
@@ -371,6 +398,7 @@
 				4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */,
 				4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */,
 				48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */,
+				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */; };
+		48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CD927997246008F2AD1 /* ExchangeUseCase.swift */; };
 		48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */; };
 		48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */; };
 		48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDF2799728C008F2AD1 /* CoinListView.swift */; };
@@ -52,6 +54,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; };
+		48256CD927997246008F2AD1 /* ExchangeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCase.swift; sourceTree = "<group>"; };
 		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; };
 		48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModel.swift; sourceTree = "<group>"; };
 		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
@@ -161,6 +165,8 @@
 			children = (
 				48256CD42799715A008F2AD1 /* Components */,
 				4881F42827979E6600472C90 /* ExchangeViewController.swift */,
+				48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */,
+				48256CD927997246008F2AD1 /* ExchangeUseCase.swift */,
 			);
 			path = Exchange;
 			sourceTree = "<group>";
@@ -402,9 +408,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
 				48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */,
+				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */; };
+		48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */; };
 		48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDF2799728C008F2AD1 /* CoinListView.swift */; };
 		48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE127997298008F2AD1 /* CoinListViewModel.swift */; };
 		48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */; };
@@ -50,6 +52,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; };
+		48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModel.swift; sourceTree = "<group>"; };
 		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
 		48256CE127997298008F2AD1 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
 		48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewCell.swift; sourceTree = "<group>"; };
@@ -108,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				48256CD52799716C008F2AD1 /* CoinList */,
+				48256CD627997179008F2AD1 /* ExchangeSearchBar */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -120,6 +125,15 @@
 				48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */,
 			);
 			path = CoinList;
+			sourceTree = "<group>";
+		};
+		48256CD627997179008F2AD1 /* ExchangeSearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */,
+				48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */,
+			);
+			path = ExchangeSearchBar;
 			sourceTree = "<group>";
 		};
 		4881F42327979D8B00472C90 /* Resources */ = {
@@ -390,6 +404,7 @@
 			files = (
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
+				48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */,
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
@@ -398,6 +413,7 @@
 				4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */,
 				4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */,
 				48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */,
+				48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */,
 				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CDF2799728C008F2AD1 /* CoinListView.swift */; };
 		48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE127997298008F2AD1 /* CoinListViewModel.swift */; };
 		48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */; };
+		48256CE72799732E008F2AD1 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48256CE62799732E008F2AD1 /* NetworkManager.swift */; };
 		4881F42727979E5200472C90 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42627979E5200472C90 /* TabBarController.swift */; };
 		4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42827979E6600472C90 /* ExchangeViewController.swift */; };
 		4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42D2797A1C400472C90 /* ProductServiceViewController.swift */; };
@@ -61,6 +62,7 @@
 		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
 		48256CE127997298008F2AD1 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
 		48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewCell.swift; sourceTree = "<group>"; };
+		48256CE62799732E008F2AD1 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4881F42627979E5200472C90 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		4881F42827979E6600472C90 /* ExchangeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewController.swift; sourceTree = "<group>"; };
 		4881F42D2797A1C400472C90 /* ProductServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductServiceViewController.swift; sourceTree = "<group>"; };
@@ -138,6 +140,21 @@
 				48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */,
 			);
 			path = ExchangeSearchBar;
+			sourceTree = "<group>";
+		};
+		48256CE52799730A008F2AD1 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				48256CE62799732E008F2AD1 /* NetworkManager.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		48256CE827997415008F2AD1 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Entity;
 			sourceTree = "<group>";
 		};
 		4881F42327979D8B00472C90 /* Resources */ = {
@@ -239,6 +256,8 @@
 			children = (
 				4881F42427979DD300472C90 /* TabBar */,
 				4881F42527979DDF00472C90 /* Exchange */,
+				48256CE52799730A008F2AD1 /* Network */,
+				48256CE827997415008F2AD1 /* Entity */,
 				4881F42327979D8B00472C90 /* Resources */,
 				4881F4322797A25100472C90 /* TBD */,
 			);
@@ -412,6 +431,7 @@
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
 				48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */,
+				48256CE72799732E008F2AD1 /* NetworkManager.swift in Sources */,
 				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListView.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListView.swift
@@ -1,0 +1,12 @@
+//
+//  CoinListView.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import UIKit
+
+final class CoinListView: UITableView {
+  
+}

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCell.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCell.swift
@@ -1,0 +1,12 @@
+//
+//  CoinListViewCell.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import UIKit
+
+final class CoinListViewCell: UITableViewCell {
+  
+}

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  CoinListViewModel.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import Foundation
+
+struct CoinListViewModel {
+  
+}

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -1,0 +1,12 @@
+//
+//  ExchangeSearchBar.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import UIKit
+
+final class ExchangeSearchBar: UISearchBar {
+  
+}

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  ExchangeSearchBarViewModel.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import Foundation
+
+struct ExchangeSearchBarViewModel {
+  
+}

--- a/Bithumb/Bithumb/Exchange/ExchangeUseCase.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  ExchangeUseCase.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import Foundation
+
+struct ExchangeUseCase {
+  
+}

--- a/Bithumb/Bithumb/Exchange/ExchangeViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  ExchangeViewModel.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import Foundation
+
+struct ExchangeViewModel {
+  
+}

--- a/Bithumb/Bithumb/Network/NetworkManager.swift
+++ b/Bithumb/Bithumb/Network/NetworkManager.swift
@@ -1,0 +1,12 @@
+//
+//  NetworkManager.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/20.
+//
+
+import Foundation
+
+struct NetworkManager {
+  
+}


### PR DESCRIPTION
## 배경
- #5 
- 원활한 팀 협업을 위해 거래소(Exchange) 화면의 전체 구조를 설계하고 빈 Structure를 구현해요
- 세부적인 구현에서 변화나 추가가 있을 예정이지만, 설계의 밑그림을 목적으로 이번 티켓을 정의했어요

## 수정 내역
- 거래소 ViewModel 및 Exchange 추가
- 거래소 화면에서 사용될 TableView 및 SearchBar 추가
- 네트워킹 객체 추가
- Entity 디렉토리 추가

## 리뷰 노트
- 네트워크 객체는 거래소 화면 뿐만 아니라 다른 화면에서도 사용 가능한 프로젝트 전반에 영향을 미치는 객체라 최상단 디렉토리의 하위 디렉토리로 설정했어요. 네트워킹에 추가로 필요한 객체나 기능은 추후 다른 티켓에서 처리할 예정이에요.
- Entity 역시 네트워크 객체에서 받아올 첫 데이터 형태라 네트워크 객체와 같은 위치에 구현했어요. Entity는 폴더만 구현하고 추후 협의를 통해 네이밍을 정한 후 구현할 예정이에요.
- ExchangeViewController의 MVVM에서 필요한 ViewModel과 UseCase를 추가했어요.
- ExchangeViewController에 포함된 TableView와 SearchBar의 로직에 필요한 structure 객체를 추가했어요.