### PR TITLE
[#7] 거래소 화면에서 코인을 검색하기 위한 SearchBar영역의 UI를 구현해요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		48FDD0392795422F002F0050 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD0382795422F002F0050 /* RxCocoa */; };
 		48FDD03B2795422F002F0050 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03A2795422F002F0050 /* RxRelay */; };
 		48FDD03D2795422F002F0050 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03C2795422F002F0050 /* RxSwift */; };
+		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		48FDD018279541E4002F0050 /* BithumbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BithumbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FDD01C279541E4002F0050 /* BithumbUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbUITests.swift; sourceTree = "<group>"; };
 		48FDD01E279541E4002F0050 /* BithumbUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 				48FDD004279541E4002F0050 /* Assets.xcassets */,
 				48FDD006279541E4002F0050 /* LaunchScreen.storyboard */,
 				48FDD009279541E4002F0050 /* Info.plist */,
+				B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
+				B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */,
 				48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */,
 				48256CE72799732E008F2AD1 /* NetworkManager.swift in Sources */,
 				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -57,14 +57,14 @@
 /* Begin PBXFileReference section */
 		48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; };
 		48256CD927997246008F2AD1 /* ExchangeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCase.swift; sourceTree = "<group>"; };
-		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; };
+		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; tabWidth = 2; };
 		48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModel.swift; sourceTree = "<group>"; };
 		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
 		48256CE127997298008F2AD1 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
 		48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewCell.swift; sourceTree = "<group>"; };
 		48256CE62799732E008F2AD1 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4881F42627979E5200472C90 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
-		4881F42827979E6600472C90 /* ExchangeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewController.swift; sourceTree = "<group>"; };
+		4881F42827979E6600472C90 /* ExchangeViewController.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeViewController.swift; sourceTree = "<group>"; tabWidth = 2; };
 		4881F42D2797A1C400472C90 /* ProductServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductServiceViewController.swift; sourceTree = "<group>"; };
 		4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAssetViewController.swift; sourceTree = "<group>"; };
 		4881F4332797A29900472C90 /* TransactionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewController.swift; sourceTree = "<group>"; };

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -30,8 +30,8 @@ final class ExchangeSearchBar: UISearchBar {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    configure()
-    layout()
+    self.configure()
+    self.layout()
   }
   
   required init?(coder: NSCoder) {
@@ -39,17 +39,18 @@ final class ExchangeSearchBar: UISearchBar {
   }
   
   private func layout() {
-    self.addSubview(giftButton)
-    self.addSubview(bellButton)
+    [giftButton, bellButton].forEach {
+      self.addSubview($0)
+    }
     
     self.searchTextField.snp.makeConstraints {
       $0.leading.equalToSuperview().offset(12)
-      $0.trailing.equalTo(giftButton.snp.leading).offset(-12)
+      $0.trailing.equalTo(self.giftButton.snp.leading).offset(-12)
       $0.centerY.equalToSuperview()
     }
     
     self.giftButton.snp.makeConstraints {
-      $0.trailing.equalTo(bellButton.snp.leading).offset(-12)
+      $0.trailing.equalTo(self.bellButton.snp.leading).offset(-12)
       $0.centerY.equalToSuperview()
     }
     

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -7,29 +7,77 @@
 
 import UIKit
 
+import SnapKit
 import Then
 
 final class ExchangeSearchBar: UISearchBar {
+
+  //MARK:  Properties
+  
+  private let giftButton = UIButton().then {
+    $0.setImage(UIImage(systemName: "gift"), for: .normal)
+    $0.tintColor = .black
+  }
+  
+  private let bellButton = UIButton().then {
+    $0.setImage(UIImage(systemName: "bell"), for: .normal)
+    $0.tintColor = .black
+  }
+  
+  
+  // MARK: Initializers
   
   override init(frame: CGRect) {
     super.init(frame: frame)
-    attribute()
+
+    configure()
+    layout()
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
-  private func attribute() {
+  private func layout() {
+    self.addSubview(giftButton)
+    self.addSubview(bellButton)
+    
+    self.searchTextField.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(12)
+      $0.trailing.equalTo(giftButton.snp.leading).offset(-12)
+      $0.centerY.equalToSuperview()
+    }
+    
+    self.giftButton.snp.makeConstraints {
+      $0.trailing.equalTo(bellButton.snp.leading).offset(-12)
+      $0.centerY.equalToSuperview()
+    }
+    
+    self.bellButton.snp.makeConstraints {
+      $0.trailing.equalToSuperview().offset(-12)
+      $0.centerY.equalToSuperview()
+    }
+  }
+  
+  private func configure() {
     self.searchTextField.do {
       $0.layer.borderWidth = 2
-      $0.layer.borderColor = UIColor(red: 227/255, green: 129/255, blue: 30/255, alpha: 1).cgColor
+      $0.layer.borderColor = UIColor(
+        red: 227/255,
+        green: 129/255,
+        blue: 30/255,
+        alpha: 1
+      ).cgColor
       $0.layer.cornerRadius = 10
       $0.leftView?.tintColor = .black
       $0.backgroundColor = .systemBackground
       $0.placeholder = "코인명 또는 심볼 검색"
-      $0.tintColor = UIColor(red: 227/255, green: 129/255, blue: 30/255, alpha: 1)
+      $0.tintColor = UIColor(
+        red: 227/255,
+        green: 129/255,
+        blue: 30/255,
+        alpha: 1
+      )
     }
   }
-  
 }

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -62,22 +62,12 @@ final class ExchangeSearchBar: UISearchBar {
   private func configure() {
     self.searchTextField.do {
       $0.layer.borderWidth = 2
-      $0.layer.borderColor = UIColor(
-        red: 227/255,
-        green: 129/255,
-        blue: 30/255,
-        alpha: 1
-      ).cgColor
+      $0.layer.borderColor = UIColor.bithumb.cgColor
       $0.layer.cornerRadius = 10
       $0.leftView?.tintColor = .black
       $0.backgroundColor = .systemBackground
       $0.placeholder = "코인명 또는 심볼 검색"
-      $0.tintColor = UIColor(
-        red: 227/255,
-        green: 129/255,
-        blue: 30/255,
-        alpha: 1
-      )
+      $0.tintColor = UIColor.bithumb
     }
   }
 }

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -7,6 +7,29 @@
 
 import UIKit
 
+import Then
+
 final class ExchangeSearchBar: UISearchBar {
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    attribute()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func attribute() {
+    self.searchTextField.do {
+      $0.layer.borderWidth = 2
+      $0.layer.borderColor = UIColor(red: 227/255, green: 129/255, blue: 30/255, alpha: 1).cgColor
+      $0.layer.cornerRadius = 10
+      $0.leftView?.tintColor = .black
+      $0.backgroundColor = .systemBackground
+      $0.placeholder = "코인명 또는 심볼 검색"
+      $0.tintColor = UIColor(red: 227/255, green: 129/255, blue: 30/255, alpha: 1)
+    }
+  }
   
 }

--- a/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
@@ -7,49 +7,9 @@
 
 import UIKit
 
-import Then
-
 final class ExchangeViewController: UIViewController {
-  
-  // MARK: Properties
-  
-  private let exchangeSearchBar = ExchangeSearchBar()
-  
-  private let giftButton = UIButton(frame: CGRect(
-     x: 0,
-     y: 0,
-     width: 30,
-     height: 20
-   )).then {
-     let giftImage = UIImage(systemName: "gift")
-     $0.setImage(giftImage, for: .normal)
-     $0.tintColor = .black
-   }
-  
-   private let bellButton = UIButton(frame: CGRect(
-     x: 0,
-     y: 0,
-     width: 30,
-     height: 20
-   )).then {
-     let bellImage = UIImage(systemName: "bell")
-     $0.setImage(bellImage, for: .normal)
-     $0.tintColor = .black
-   }
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    layout()
-  }
-  
-  private func layout() {
-    self.navigationItem.do {
-      $0.titleView = self.exchangeSearchBar
-      $0.rightBarButtonItems = [
-        UIBarButtonItem(customView: self.bellButton),
-        UIBarButtonItem(customView: self.giftButton)
-      ]
-    }
   }
 }

--- a/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
@@ -7,9 +7,24 @@
 
 import UIKit
 
+import Then
+
 final class ExchangeViewController: UIViewController {
+  
+  // MARK: Properties
+  
+  let exchangeSearchBar = ExchangeSearchBar()
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    
+    layout()
   }
+  
+  private func layout() {
+    self.navigationItem.do {
+      $0.titleView = self.exchangeSearchBar
+    }
+  }
+  
 }

--- a/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
@@ -13,7 +13,29 @@ final class ExchangeViewController: UIViewController {
   
   // MARK: Properties
   
-  let exchangeSearchBar = ExchangeSearchBar()
+  private let exchangeSearchBar = ExchangeSearchBar()
+  
+  private let giftButton = UIButton(frame: CGRect(
+     x: 0,
+     y: 0,
+     width: 30,
+     height: 20
+   )).then {
+     let giftImage = UIImage(systemName: "gift")
+     $0.setImage(giftImage, for: .normal)
+     $0.tintColor = .black
+   }
+  
+   private let bellButton = UIButton(frame: CGRect(
+     x: 0,
+     y: 0,
+     width: 30,
+     height: 20
+   )).then {
+     let bellImage = UIImage(systemName: "bell")
+     $0.setImage(bellImage, for: .normal)
+     $0.tintColor = .black
+   }
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -24,7 +46,10 @@ final class ExchangeViewController: UIViewController {
   private func layout() {
     self.navigationItem.do {
       $0.titleView = self.exchangeSearchBar
+      $0.rightBarButtonItems = [
+        UIBarButtonItem(customView: self.bellButton),
+        UIBarButtonItem(customView: self.giftButton)
+      ]
     }
   }
-  
 }

--- a/Bithumb/Bithumb/Resources/UIColor + Ext.swift
+++ b/Bithumb/Bithumb/Resources/UIColor + Ext.swift
@@ -1,0 +1,19 @@
+//
+//  UIColor + Ext.swift
+//  Bithumb
+//
+//  Created by 김민성 on 2022/01/21.
+//
+
+import UIKit
+
+extension UIColor {
+    static var bithumb: UIColor {
+        return UIColor(
+            red: 227/255,
+            green: 129/255,
+            blue: 30/255,
+            alpha: 1
+          )
+    }
+}


### PR DESCRIPTION
## 배경

- #8 
- 거래소 화면의 navgationBar영역에 코인을 검색하기 위한 SearchBar와 Button들을 구현해요

## 수정 내역
- ExchangeSearchBar에서 SearchBar에 대한 설정을 추가해줬어요
- ExchangeViewController에서 nagavitionBar의 title에 ExchangeSearchBar를 추가했어요
- ExchagneViewController에서 navigationBar의 BarButtonItem을 추가했어요
- UIColor extension을 통해 Bithumb 색상을 추가했어요

## 테스트 방법
- 구동테스트
![스크린샷 2022-01-21 오후 1 36 38](https://user-images.githubusercontent.com/56648865/150466782-88bdff9c-f914-4fe3-b93d-45e1da43d834.png)

## 리뷰 노트
- navigationBar의 rightBarButtonItem의 Image는 임의로 설정했어요 추후에 변경이 필요할시 변경할 예정이에요
- SearchBar의 textField의 endEdit시 키보드가 사라지게 하는 기능은 구현하지 않았어요