### PR TITLE
[#9] 거래소 화면의 SearchBarViewModel의 기능을 구현하고 CocoaPods로 마이그레이션해요

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ playground.xcworkspace
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-# Pods/
+Pods/
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 
@@ -97,5 +97,5 @@ iOSInjectionProject/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
-
+.DS_Store
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -28,14 +28,10 @@
 		48FDD013279541E4002F0050 /* BithumbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDD012279541E4002F0050 /* BithumbTests.swift */; };
 		48FDD01D279541E4002F0050 /* BithumbUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDD01C279541E4002F0050 /* BithumbUITests.swift */; };
 		48FDD01F279541E4002F0050 /* BithumbUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDD01E279541E4002F0050 /* BithumbUITestsLaunchTests.swift */; };
-		48FDD02D27954203002F0050 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD02C27954203002F0050 /* Alamofire */; };
-		48FDD0302795420D002F0050 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD02F2795420D002F0050 /* Kingfisher */; };
-		48FDD03327954213002F0050 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03227954213002F0050 /* Then */; };
-		48FDD03627954223002F0050 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03527954223002F0050 /* SnapKit */; };
-		48FDD0392795422F002F0050 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD0382795422F002F0050 /* RxCocoa */; };
-		48FDD03B2795422F002F0050 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03A2795422F002F0050 /* RxRelay */; };
-		48FDD03D2795422F002F0050 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 48FDD03C2795422F002F0050 /* RxSwift */; };
+		6C6755D0D77E50E4E4F23A6B /* Pods_BithumbTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */; };
+		AECFA866C0A5ED5A74EF7698 /* Pods_Bithumb_BithumbUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */; };
 		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
+		F19014D04656742DAD3CEE42 /* Pods_Bithumb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +52,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		114D3A1E134DE0667AC5648F /* Pods-Bithumb-BithumbUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb-BithumbUITests.release.xcconfig"; path = "Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests.release.xcconfig"; sourceTree = "<group>"; };
+		26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		41725A19228DD05069A43D6B /* Pods-BithumbTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.debug.xcconfig"; sourceTree = "<group>"; };
 		48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; };
 		48256CD927997246008F2AD1 /* ExchangeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCase.swift; sourceTree = "<group>"; };
 		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; tabWidth = 2; };
@@ -81,7 +80,13 @@
 		48FDD018279541E4002F0050 /* BithumbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BithumbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FDD01C279541E4002F0050 /* BithumbUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbUITests.swift; sourceTree = "<group>"; };
 		48FDD01E279541E4002F0050 /* BithumbUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		4B826CECF0BAC99F29B8B716 /* Pods-Bithumb.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb.release.xcconfig"; path = "Target Support Files/Pods-Bithumb/Pods-Bithumb.release.xcconfig"; sourceTree = "<group>"; };
+		57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C458E072B175DDD2D261FA3 /* Pods-Bithumb-BithumbUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb-BithumbUITests.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
+		C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb_BithumbUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.release.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.release.xcconfig"; sourceTree = "<group>"; };
+		EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb/Pods-Bithumb.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,13 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48FDD03B2795422F002F0050 /* RxRelay in Frameworks */,
-				48FDD0302795420D002F0050 /* Kingfisher in Frameworks */,
-				48FDD03627954223002F0050 /* SnapKit in Frameworks */,
-				48FDD0392795422F002F0050 /* RxCocoa in Frameworks */,
-				48FDD03327954213002F0050 /* Then in Frameworks */,
-				48FDD02D27954203002F0050 /* Alamofire in Frameworks */,
-				48FDD03D2795422F002F0050 /* RxSwift in Frameworks */,
+				F19014D04656742DAD3CEE42 /* Pods_Bithumb.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6C6755D0D77E50E4E4F23A6B /* Pods_BithumbTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,12 +110,26 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AECFA866C0A5ED5A74EF7698 /* Pods_Bithumb_BithumbUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		043277A5FA3526FC4A626215 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */,
+				4B826CECF0BAC99F29B8B716 /* Pods-Bithumb.release.xcconfig */,
+				6C458E072B175DDD2D261FA3 /* Pods-Bithumb-BithumbUITests.debug.xcconfig */,
+				114D3A1E134DE0667AC5648F /* Pods-Bithumb-BithumbUITests.release.xcconfig */,
+				41725A19228DD05069A43D6B /* Pods-BithumbTests.debug.xcconfig */,
+				CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		48256CD42799715A008F2AD1 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -241,6 +255,8 @@
 				48FDD011279541E4002F0050 /* BithumbTests */,
 				48FDD01B279541E4002F0050 /* BithumbUITests */,
 				48FDCFF9279541E2002F0050 /* Products */,
+				043277A5FA3526FC4A626215 /* Pods */,
+				5ECF25BAAF858A5881CC3B80 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -284,6 +300,16 @@
 			path = BithumbUITests;
 			sourceTree = "<group>";
 		};
+		5ECF25BAAF858A5881CC3B80 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */,
+				C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */,
+				26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -291,9 +317,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48FDD022279541E4002F0050 /* Build configuration list for PBXNativeTarget "Bithumb" */;
 			buildPhases = (
+				FC9A46994529C1A29C52F659 /* [CP] Check Pods Manifest.lock */,
 				48FDCFF4279541E2002F0050 /* Sources */,
 				48FDCFF5279541E2002F0050 /* Frameworks */,
 				48FDCFF6279541E2002F0050 /* Resources */,
+				6805D086DA470C62B7B7827C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -301,13 +329,6 @@
 			);
 			name = Bithumb;
 			packageProductDependencies = (
-				48FDD02C27954203002F0050 /* Alamofire */,
-				48FDD02F2795420D002F0050 /* Kingfisher */,
-				48FDD03227954213002F0050 /* Then */,
-				48FDD03527954223002F0050 /* SnapKit */,
-				48FDD0382795422F002F0050 /* RxCocoa */,
-				48FDD03A2795422F002F0050 /* RxRelay */,
-				48FDD03C2795422F002F0050 /* RxSwift */,
 			);
 			productName = Bithumb;
 			productReference = 48FDCFF8279541E2002F0050 /* Bithumb.app */;
@@ -317,9 +338,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48FDD025279541E4002F0050 /* Build configuration list for PBXNativeTarget "BithumbTests" */;
 			buildPhases = (
+				9D4CF2E71FCDD62F6A84EB20 /* [CP] Check Pods Manifest.lock */,
 				48FDD00A279541E4002F0050 /* Sources */,
 				48FDD00B279541E4002F0050 /* Frameworks */,
 				48FDD00C279541E4002F0050 /* Resources */,
+				93075120C7367D652F85DFB8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -335,9 +358,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48FDD028279541E4002F0050 /* Build configuration list for PBXNativeTarget "BithumbUITests" */;
 			buildPhases = (
+				0B9C6E5400BF5D2ADBA22ED8 /* [CP] Check Pods Manifest.lock */,
 				48FDD014279541E4002F0050 /* Sources */,
 				48FDD015279541E4002F0050 /* Frameworks */,
 				48FDD016279541E4002F0050 /* Resources */,
+				479E90F3FED93D0FCA21019D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -382,11 +407,6 @@
 			);
 			mainGroup = 48FDCFEF279541E2002F0050;
 			packageReferences = (
-				48FDD02B27954203002F0050 /* XCRemoteSwiftPackageReference "Alamofire" */,
-				48FDD02E2795420D002F0050 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				48FDD03127954213002F0050 /* XCRemoteSwiftPackageReference "Then" */,
-				48FDD03427954223002F0050 /* XCRemoteSwiftPackageReference "snapkit" */,
-				48FDD0372795422F002F0050 /* XCRemoteSwiftPackageReference "rxswift" */,
 			);
 			productRefGroup = 48FDCFF9279541E2002F0050 /* Products */;
 			projectDirPath = "";
@@ -424,6 +444,126 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0B9C6E5400BF5D2ADBA22ED8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Bithumb-BithumbUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		479E90F3FED93D0FCA21019D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6805D086DA470C62B7B7827C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Bithumb/Pods-Bithumb-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Bithumb/Pods-Bithumb-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Bithumb/Pods-Bithumb-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		93075120C7367D652F85DFB8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-BithumbTests/Pods-BithumbTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-BithumbTests/Pods-BithumbTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BithumbTests/Pods-BithumbTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9D4CF2E71FCDD62F6A84EB20 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BithumbTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FC9A46994529C1A29C52F659 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Bithumb-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		48FDCFF4279541E2002F0050 /* Sources */ = {
@@ -612,6 +752,7 @@
 		};
 		48FDD023279541E4002F0050 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -639,6 +780,7 @@
 		};
 		48FDD024279541E4002F0050 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4B826CECF0BAC99F29B8B716 /* Pods-Bithumb.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -666,6 +808,7 @@
 		};
 		48FDD026279541E4002F0050 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 41725A19228DD05069A43D6B /* Pods-BithumbTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -691,6 +834,7 @@
 		};
 		48FDD027279541E4002F0050 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -716,6 +860,7 @@
 		};
 		48FDD029279541E4002F0050 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C458E072B175DDD2D261FA3 /* Pods-Bithumb-BithumbUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -739,6 +884,7 @@
 		};
 		48FDD02A279541E4002F0050 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 114D3A1E134DE0667AC5648F /* Pods-Bithumb-BithumbUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -800,87 +946,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		48FDD02B27954203002F0050 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Alamofire/Alamofire";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-		48FDD02E2795420D002F0050 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-		48FDD03127954213002F0050 /* XCRemoteSwiftPackageReference "Then" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/devxoul/Then";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-		48FDD03427954223002F0050 /* XCRemoteSwiftPackageReference "snapkit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/snapkit/snapkit.git";
-			requirement = {
-				branch = develop;
-				kind = branch;
-			};
-		};
-		48FDD0372795422F002F0050 /* XCRemoteSwiftPackageReference "rxswift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/reactivex/rxswift.git";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		48FDD02C27954203002F0050 /* Alamofire */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD02B27954203002F0050 /* XCRemoteSwiftPackageReference "Alamofire" */;
-			productName = Alamofire;
-		};
-		48FDD02F2795420D002F0050 /* Kingfisher */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD02E2795420D002F0050 /* XCRemoteSwiftPackageReference "Kingfisher" */;
-			productName = Kingfisher;
-		};
-		48FDD03227954213002F0050 /* Then */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD03127954213002F0050 /* XCRemoteSwiftPackageReference "Then" */;
-			productName = Then;
-		};
-		48FDD03527954223002F0050 /* SnapKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD03427954223002F0050 /* XCRemoteSwiftPackageReference "snapkit" */;
-			productName = SnapKit;
-		};
-		48FDD0382795422F002F0050 /* RxCocoa */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD0372795422F002F0050 /* XCRemoteSwiftPackageReference "rxswift" */;
-			productName = RxCocoa;
-		};
-		48FDD03A2795422F002F0050 /* RxRelay */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD0372795422F002F0050 /* XCRemoteSwiftPackageReference "rxswift" */;
-			productName = RxRelay;
-		};
-		48FDD03C2795422F002F0050 /* RxSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 48FDD0372795422F002F0050 /* XCRemoteSwiftPackageReference "rxswift" */;
-			productName = RxSwift;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 48FDCFF0279541E2002F0050 /* Project object */;
 }

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */; };
 		4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F4332797A29900472C90 /* TransactionViewController.swift */; };
 		4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F4352797A2B800472C90 /* MoreOptionViewController.swift */; };
+		488F9E81279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488F9E80279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift */; };
 		48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDCFFB279541E2002F0050 /* AppDelegate.swift */; };
 		48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDCFFD279541E2002F0050 /* SceneDelegate.swift */; };
 		48FDD005279541E4002F0050 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 48FDD004279541E4002F0050 /* Assets.xcassets */; };
@@ -69,6 +70,7 @@
 		4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAssetViewController.swift; sourceTree = "<group>"; };
 		4881F4332797A29900472C90 /* TransactionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewController.swift; sourceTree = "<group>"; };
 		4881F4352797A2B800472C90 /* MoreOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionViewController.swift; sourceTree = "<group>"; };
+		488F9E80279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModelTests.swift; sourceTree = "<group>"; };
 		48FDCFF8279541E2002F0050 /* Bithumb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bithumb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FDCFFB279541E2002F0050 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		48FDCFFD279541E2002F0050 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -248,6 +250,30 @@
 			path = TBD;
 			sourceTree = "<group>";
 		};
+		488F9E7D279BA7BF0021A545 /* Exchange */ = {
+			isa = PBXGroup;
+			children = (
+				488F9E7E279BA7C70021A545 /* Components */,
+			);
+			path = Exchange;
+			sourceTree = "<group>";
+		};
+		488F9E7E279BA7C70021A545 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				488F9E7F279BA7D80021A545 /* ExchangeSearchBar */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		488F9E7F279BA7D80021A545 /* ExchangeSearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				488F9E80279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift */,
+			);
+			path = ExchangeSearchBar;
+			sourceTree = "<group>";
+		};
 		48FDCFEF279541E2002F0050 = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +312,7 @@
 		48FDD011279541E4002F0050 /* BithumbTests */ = {
 			isa = PBXGroup;
 			children = (
+				488F9E7D279BA7BF0021A545 /* Exchange */,
 				48FDD012279541E4002F0050 /* BithumbTests.swift */,
 			);
 			path = BithumbTests;
@@ -594,6 +621,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				488F9E81279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift in Sources */,
 				48FDD013279541E4002F0050 /* BithumbTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */; };
 		4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F4332797A29900472C90 /* TransactionViewController.swift */; };
 		4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881F4352797A2B800472C90 /* MoreOptionViewController.swift */; };
+		488F9E7C279BA68F0021A545 /* TickerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488F9E7B279BA68E0021A545 /* TickerResponse.swift */; };
 		488F9E81279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488F9E80279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift */; };
 		48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDCFFB279541E2002F0050 /* AppDelegate.swift */; };
 		48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FDCFFD279541E2002F0050 /* SceneDelegate.swift */; };
@@ -70,6 +71,7 @@
 		4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAssetViewController.swift; sourceTree = "<group>"; };
 		4881F4332797A29900472C90 /* TransactionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewController.swift; sourceTree = "<group>"; };
 		4881F4352797A2B800472C90 /* MoreOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionViewController.swift; sourceTree = "<group>"; };
+		488F9E7B279BA68E0021A545 /* TickerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerResponse.swift; sourceTree = "<group>"; };
 		488F9E80279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModelTests.swift; sourceTree = "<group>"; };
 		48FDCFF8279541E2002F0050 /* Bithumb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bithumb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FDCFFB279541E2002F0050 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 		48256CE827997415008F2AD1 /* Entity */ = {
 			isa = PBXGroup;
 			children = (
+				488F9E7B279BA68E0021A545 /* TickerResponse.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -613,6 +616,7 @@
 				4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */,
 				48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */,
 				48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */,
+				488F9E7C279BA68F0021A545 /* TickerResponse.swift in Sources */,
 				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb.xcworkspace/contents.xcworkspacedata
+++ b/Bithumb/Bithumb.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Bithumb.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Bithumb/Bithumb.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Bithumb/Bithumb.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Bithumb/Bithumb.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bithumb/Bithumb.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire",
         "state": {
           "branch": "master",
-          "revision": "e1f6c211747bce531f4171848f62d9cb6de0cc82",
+          "revision": "3e5fc5d8ae939b655929a0edd60d3bb70f38027f",
           "version": null
         }
       },

--- a/Bithumb/Bithumb/Entity/TickerResponse.swift
+++ b/Bithumb/Bithumb/Entity/TickerResponse.swift
@@ -1,0 +1,8 @@
+//
+//  TickerResponse.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/01/22.
+//
+
+import Foundation

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
@@ -5,8 +5,24 @@
 //  Created by Seungjin Baek on 2022/01/20.
 //
 
-import Foundation
+import RxCocoa
+import RxSwift
 
-struct ExchangeSearchBarViewModel {
+final class ExchangeSearchBarViewModel {
   
+  // MARK: Properties
+  
+  let inputText = PublishRelay<String>()
+  let searchButtonTapped = PublishRelay<Void>()
+  let queryText: Observable<String>
+  
+  
+  // MARK: Initializers
+  
+  init() {
+    self.queryText = self.searchButtonTapped
+      .withLatestFrom(self.inputText)
+      .filter { !$0.isEmpty }
+      .distinctUntilChanged()
+  }
 }

--- a/Bithumb/BithumbTests/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModelTests.swift
+++ b/Bithumb/BithumbTests/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModelTests.swift
@@ -1,0 +1,118 @@
+//
+//  ExchangeSearchBarViewModel.swift
+//  BithumbTests
+//
+//  Created by Seungjin Baek on 2022/01/22.
+//
+
+import XCTest
+@testable import Bithumb
+
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+
+class ExchangeSearchBarViewModelTests: XCTestCase {
+  
+  var sut: ExchangeSearchBarViewModel!
+  var scheduler: TestScheduler!
+  var disposeBag: DisposeBag!
+  
+  
+  // MARK: Settings
+  
+  override func setUp() {
+    self.sut = ExchangeSearchBarViewModel()
+    self.scheduler = TestScheduler(initialClock: 0)
+    self.disposeBag = DisposeBag()
+  }
+  
+  override func tearDown() {
+    self.disposeBag = DisposeBag()
+  }
+  
+  
+  // MARK: Tests
+  
+  func test_검색_버튼을_눌렀을_때_입력된_문자열이_없는_경우() throws {
+    //given
+    self.scheduler.createColdObservable(
+      [
+        .next(5, "")
+      ]
+    ).bind(to: self.sut.inputText)
+      .disposed(by: self.disposeBag)
+    
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(10, ())
+      ]
+    ).bind(to: self.sut.searchButtonTapped)
+      .disposed(by: self.disposeBag)
+    
+    //then
+    expect(self.sut.queryText)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal([]))
+  }
+  
+  func test_검색_버튼을_눌렀을_때_입력된_문자열이_있는_경우() throws {
+    //given
+    let keyword = "테스트 검색어"
+    self.scheduler.createColdObservable(
+      [
+        .next(5, keyword)
+      ]
+    ).bind(to: self.sut.inputText)
+      .disposed(by: self.disposeBag)
+    
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(10, ())
+      ]
+    ).bind(to: self.sut.searchButtonTapped)
+      .disposed(by: self.disposeBag)
+    
+    //then
+    expect(self.sut.queryText)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal(
+        [
+          .next(10, keyword)
+        ]
+      ))
+  }
+  
+  func test_검색_버튼을_다시_눌렀을_때_입력된_문자열이_기존의_입력과_같은_경우() throws {
+    //given
+    let keyword = "테스트 검색어"
+    self.scheduler.createColdObservable(
+      [
+        .next(5, keyword),
+        .next(10, keyword)
+      ]
+    ).bind(to: self.sut.inputText)
+      .disposed(by: self.disposeBag)
+    
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(6, ()),
+        .next(11, ())
+      ]
+    ).bind(to: self.sut.searchButtonTapped)
+      .disposed(by: self.disposeBag)
+    
+    //then
+    expect(self.sut.queryText)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal(
+        [
+          .next(6, keyword)
+        ]
+      ))
+  }
+}

--- a/Bithumb/Podfile
+++ b/Bithumb/Podfile
@@ -1,0 +1,28 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '13.0'
+
+target 'Bithumb' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+  pod 'RxSwift', '6.5.0'
+  pod 'RxCocoa', '6.5.0'
+  pod 'Alamofire', '~> 5.5'
+  pod 'Then'
+  pod 'SnapKit', '~> 5.0.0'
+  pod 'Kingfisher', '~> 7.0'
+
+  # Pods for Bithumb
+
+  target 'BithumbTests' do
+    inherit! :search_paths
+    # Pods for testing
+  pod 'RxTest', '6.5.0'
+  pod 'Nimble'
+  pod 'RxNimble', subspecs: ['RxBlocking', 'RxTest']
+  end
+
+  target 'BithumbUITests' do
+    # Pods for testing
+  end
+
+end

--- a/Bithumb/Podfile.lock
+++ b/Bithumb/Podfile.lock
@@ -1,0 +1,68 @@
+PODS:
+  - Alamofire (5.5.0)
+  - Kingfisher (7.1.2)
+  - Nimble (9.2.1)
+  - RxBlocking (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxCocoa (6.5.0):
+    - RxRelay (= 6.5.0)
+    - RxSwift (= 6.5.0)
+  - RxNimble/Core (5.1.2):
+    - Nimble (~> 9.2)
+    - RxSwift (~> 6.0)
+  - RxNimble/RxBlocking (5.1.2):
+    - RxBlocking
+    - RxNimble/Core
+  - RxNimble/RxTest (5.1.2):
+    - RxNimble/Core
+    - RxTest
+  - RxRelay (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxSwift (6.5.0)
+  - RxTest (6.5.0):
+    - RxSwift (= 6.5.0)
+  - SnapKit (5.0.1)
+  - Then (2.7.0)
+
+DEPENDENCIES:
+  - Alamofire (~> 5.5)
+  - Kingfisher (~> 7.0)
+  - Nimble
+  - RxCocoa (= 6.5.0)
+  - RxNimble/RxBlocking
+  - RxNimble/RxTest
+  - RxSwift (= 6.5.0)
+  - RxTest (= 6.5.0)
+  - SnapKit (~> 5.0.0)
+  - Then
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - Kingfisher
+    - Nimble
+    - RxBlocking
+    - RxCocoa
+    - RxNimble
+    - RxRelay
+    - RxSwift
+    - RxTest
+    - SnapKit
+    - Then
+
+SPEC CHECKSUMS:
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
+  Kingfisher: 44ed6a8504763f27bab46163adfac83f5deb240c
+  Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
+  RxBlocking: 04b5fd28bb5ea49f7d64b80db8bbfe50d9cc1c7d
+  RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
+  RxNimble: 60c8162b1518306a11d0c272a65ade133b209670
+  RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
+  RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
+  RxTest: eb2d23adefc5a5ebf5779c7792fa3edfe6ebcc17
+  SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
+  Then: acfe0be7e98221c6204e12f8161459606d5d822d
+
+PODFILE CHECKSUM: dee262d9c8160fbfcd261dd9aa04e74a57478bbb
+
+COCOAPODS: 1.11.2


### PR DESCRIPTION
## 배경
- #9 
- Swift Package Manager를 CocoaPods로 마이그레이션해요
- 거래소 화면에서 사용할 SearchBar의 ViewModel을 구현해요

## 수정 내역
- SPM을 CocoaPods로 마이그레이션 했어요
- ExchangeSearchBarViewModel을 구현했어요
- ExchangeSearchBarViewModelTests로 구현한 ViewModel을 테스트했어요

## 테스트 방법
- 유닛테스트를 진행했어요
- 앱 사용 상황을 가정해 테스트를 진행했어요

## 리뷰 노트
- SPM을 통해 RxSwift를 사용할 경우 이슈가 발생해 CocoaPods로 마이그레이션 했어요
- 보다 명시적이고 원활한 테스트를 위해 Nimble 등의 라이브러리를 추가했어요