### PR TITLE
[#13] 거래소 화면에서 사용하기 위한 BottomSheet UI와 ViewModel을 구현해요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		6C6755D0D77E50E4E4F23A6B /* Pods_BithumbTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */; };
 		AECFA866C0A5ED5A74EF7698 /* Pods_Bithumb_BithumbUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */; };
 		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
+		C39FC5C2279DA76E008EF91A /* BottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5C1279DA76E008EF91A /* BottomSheet.swift */; };
+		C39FC5C5279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */; };
 		F19014D04656742DAD3CEE42 /* Pods_Bithumb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +90,8 @@
 		57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C458E072B175DDD2D261FA3 /* Pods-Bithumb-BithumbUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb-BithumbUITests.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
+		C39FC5C1279DA76E008EF91A /* BottomSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheet.swift; sourceTree = "<group>"; };
+		C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PriceChangedPeriodBottomSheet.swift; sourceTree = "<group>"; };
 		C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb_BithumbUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.release.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.release.xcconfig"; sourceTree = "<group>"; };
 		EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb/Pods-Bithumb.debug.xcconfig"; sourceTree = "<group>"; };
@@ -137,6 +141,7 @@
 		48256CD42799715A008F2AD1 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C39FC5C3279DA784008EF91A /* PriceChangedPeriodBottomSheet */,
 				48256CD52799716C008F2AD1 /* CoinList */,
 				48256CD627997179008F2AD1 /* ExchangeSearchBar */,
 			);
@@ -181,6 +186,7 @@
 		4881F42327979D8B00472C90 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				C39FC5BF279DA76E008EF91A /* Module */,
 				48FDCFFB279541E2002F0050 /* AppDelegate.swift */,
 				48FDCFFD279541E2002F0050 /* SceneDelegate.swift */,
 				48FDD004279541E4002F0050 /* Assets.xcassets */,
@@ -338,6 +344,30 @@
 				26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C39FC5BF279DA76E008EF91A /* Module */ = {
+			isa = PBXGroup;
+			children = (
+				C39FC5C0279DA76E008EF91A /* BottomSheet */,
+			);
+			path = Module;
+			sourceTree = "<group>";
+		};
+		C39FC5C0279DA76E008EF91A /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				C39FC5C1279DA76E008EF91A /* BottomSheet.swift */,
+			);
+			path = BottomSheet;
+			sourceTree = "<group>";
+		};
+		C39FC5C3279DA784008EF91A /* PriceChangedPeriodBottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */,
+			);
+			path = PriceChangedPeriodBottomSheet;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -600,6 +630,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C39FC5C5279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift in Sources */,
 				48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
@@ -613,6 +644,7 @@
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
 				4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */,
 				4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */,
+				C39FC5C2279DA76E008EF91A /* BottomSheet.swift in Sources */,
 				4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */,
 				48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */,
 				48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */,

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
 		C39FC5C2279DA76E008EF91A /* BottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5C1279DA76E008EF91A /* BottomSheet.swift */; };
 		C39FC5C5279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */; };
+		C39FC5D9279E3739008EF91A /* PriceChangedPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5D8279E3739008EF91A /* PriceChangedPeriodViewModel.swift */; };
+		C39FC5DB279E3764008EF91A /* Period.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5DA279E3764008EF91A /* Period.swift */; };
+		C39FC5DE279E3846008EF91A /* PriceChangedPeriodViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FC5DD279E3846008EF91A /* PriceChangedPeriodViewModelTests.swift */; };
 		F19014D04656742DAD3CEE42 /* Pods_Bithumb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */; };
 /* End PBXBuildFile section */
 
@@ -92,6 +95,9 @@
 		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
 		C39FC5C1279DA76E008EF91A /* BottomSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheet.swift; sourceTree = "<group>"; };
 		C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PriceChangedPeriodBottomSheet.swift; sourceTree = "<group>"; };
+		C39FC5D8279E3739008EF91A /* PriceChangedPeriodViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PriceChangedPeriodViewModel.swift; sourceTree = "<group>"; };
+		C39FC5DA279E3764008EF91A /* Period.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Period.swift; sourceTree = "<group>"; };
+		C39FC5DD279E3846008EF91A /* PriceChangedPeriodViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChangedPeriodViewModelTests.swift; sourceTree = "<group>"; };
 		C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb_BithumbUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.release.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.release.xcconfig"; sourceTree = "<group>"; };
 		EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb/Pods-Bithumb.debug.xcconfig"; sourceTree = "<group>"; };
@@ -270,6 +276,7 @@
 		488F9E7E279BA7C70021A545 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C39FC5DC279E3821008EF91A /* PriceChangedPeriodBottomSheet */,
 				488F9E7F279BA7D80021A545 /* ExchangeSearchBar */,
 			);
 			path = Components;
@@ -366,6 +373,16 @@
 			isa = PBXGroup;
 			children = (
 				C39FC5C4279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift */,
+				C39FC5D8279E3739008EF91A /* PriceChangedPeriodViewModel.swift */,
+				C39FC5DA279E3764008EF91A /* Period.swift */,
+			);
+			path = PriceChangedPeriodBottomSheet;
+			sourceTree = "<group>";
+		};
+		C39FC5DC279E3821008EF91A /* PriceChangedPeriodBottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				C39FC5DD279E3846008EF91A /* PriceChangedPeriodViewModelTests.swift */,
 			);
 			path = PriceChangedPeriodBottomSheet;
 			sourceTree = "<group>";
@@ -632,6 +649,7 @@
 			files = (
 				C39FC5C5279DA784008EF91A /* PriceChangedPeriodBottomSheet.swift in Sources */,
 				48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */,
+				C39FC5D9279E3739008EF91A /* PriceChangedPeriodViewModel.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				4881F42727979E5200472C90 /* TabBarController.swift in Sources */,
 				B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */,
@@ -641,6 +659,7 @@
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
+				C39FC5DB279E3764008EF91A /* Period.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
 				4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */,
 				4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */,
@@ -658,6 +677,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				488F9E81279BA8020021A545 /* ExchangeSearchBarViewModelTests.swift in Sources */,
+				C39FC5DE279E3846008EF91A /* PriceChangedPeriodViewModelTests.swift in Sources */,
 				48FDD013279541E4002F0050 /* BithumbTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/Period.swift
+++ b/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/Period.swift
@@ -1,0 +1,16 @@
+//
+//  Period.swift
+//  Bithumb
+//
+//  Created by 이영우 on 2022/01/24.
+//
+
+import Foundation
+
+enum Period: String, CaseIterable {
+  case yesterday = "어제대비"
+  case twentyFourHour = "24시간"
+  case twelveHour = "12시간"
+  case oneHour = "1시간"
+  case thirtyMinute = "30분"
+}

--- a/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodBottomSheet.swift
+++ b/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodBottomSheet.swift
@@ -1,0 +1,92 @@
+//
+//  PriceChangedPeriodBottomSheet.swift
+//  Bithumb
+//
+//  Created by 이영우 on 2022/01/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class PriceChangedPeriodBottomSheet: BottomSheet {
+  
+  // MARK: Properties
+  
+  private let titleLabel = UILabel()
+  private let descriptionLabel = UILabel()
+  private let periodListView = UITableView()
+  private let cancelButton = UIButton()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    self.layout()
+    self.attribute()
+  }
+  
+  private func layout() {
+    [self.titleLabel, self.descriptionLabel, self.periodListView, self.cancelButton].forEach {
+      self.bottomSheetView.addSubview($0)
+    }
+    
+    self.titleLabel.snp.makeConstraints {
+      $0.leading.top.equalToSuperview().inset(20)
+      $0.trailing.equalTo(self.cancelButton.snp.leading)
+    }
+
+    self.descriptionLabel.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.top.equalTo(self.titleLabel.snp.bottom).offset(10)
+    }
+
+    self.cancelButton.snp.makeConstraints {
+      $0.trailing.equalToSuperview().inset(20)
+      $0.top.bottom.equalTo(self.titleLabel)
+      $0.width.equalTo(self.cancelButton.snp.height)
+    }
+
+    self.periodListView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.top.equalTo(self.descriptionLabel.snp.bottom).offset(10)
+      $0.bottom.equalToSuperview().inset(20)
+    }
+    
+    self.defaultHeight = 320
+  }
+    
+  private func attribute() {
+    self.titleLabel.do {
+      $0.text = "변동률 기간 설정"
+      $0.font = .systemFont(ofSize: 18)
+    }
+    
+    self.descriptionLabel.do {
+      $0.text = "App 내 데이터 기준 기간이 모두 동일하게 변경됩니다.\n거래금액은 최근 24시간 기준으로 표기됩니다."
+      $0.font = .systemFont(ofSize: 12)
+      $0.numberOfLines = 2
+      $0.textColor = .gray
+    }
+    
+    self.cancelButton.do {
+      $0.setBackgroundImage(UIImage(systemName: "xmark"),
+                            for: .normal)
+      $0.tintColor = .black
+      $0.addTarget(self,
+                   action: #selector(self.tapCancelButton),
+                   for: .touchUpInside)
+    }
+    
+    self.periodListView.do {
+      $0.separatorStyle = .none
+      $0.register(UITableViewCell.self,
+                  forCellReuseIdentifier: "cell")
+      $0.isScrollEnabled = false
+    }
+  }
+  
+  @objc private func tapCancelButton() {
+    self.hideBottomSheetAndGoBack()
+  }
+}

--- a/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  PriceChangedPeriodViewModel.swift
+//  Bithumb
+//
+//  Created by 이영우 on 2022/01/24.
+//
+
+import UIKit
+
+import RxRelay
+import RxSwift
+
+final class PriceChangedPeriodViewModel {
+  
+  // MARK: Properties
+  
+  let periods = Period.allCases
+  let tapListView: BehaviorRelay<IndexPath>
+  var selectedPeriod: BehaviorRelay<Period>
+  
+  private let disposeBag = DisposeBag()
+  
+  
+  // MARK: Initializer
+  
+  init(selectedPeriod: Period) {
+    let index = Period.allCases.firstIndex(of: selectedPeriod) ?? 0
+    self.tapListView = BehaviorRelay(value: IndexPath(row: index, section: .zero))
+    self.selectedPeriod = BehaviorRelay(value: selectedPeriod)
+    
+    self.bind()
+  }
+  
+  private func bind() {
+    self.tapListView.map {
+      Period.allCases[$0.row]
+    }
+    .bind(to: self.selectedPeriod)
+    .disposed(by: self.disposeBag)
+  }
+}

--- a/Bithumb/Bithumb/Resources/Module/BottomSheet/BottomSheet.swift
+++ b/Bithumb/Bithumb/Resources/Module/BottomSheet/BottomSheet.swift
@@ -1,0 +1,104 @@
+//
+//  BottomSheetViewController.swift
+//  Bithumb
+//
+//  Created by 이영우 on 2022/01/22.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class BottomSheet: UIViewController {
+  
+  // MARK: Properties
+  
+  private let dimmedTap = UITapGestureRecognizer()
+  private let dimmedView = UIView()
+  private var bottomSheetViewTopConstraint: ConstraintMakerEditable?
+
+  let bottomSheetView = UIView()
+  var defaultHeight: CGFloat = 300
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    self.attribute()
+    self.layout()
+  }
+  
+  private func attribute() {
+    self.bottomSheetView.do {
+      $0.backgroundColor = .white
+      $0.layer.cornerRadius = 10
+      $0.layer.maskedCorners = [.layerMinXMinYCorner,
+                                .layerMaxXMinYCorner]
+      $0.clipsToBounds = true
+    }
+    
+    self.dimmedTap.do {
+      $0.addTarget(self, action: #selector(self.dimmedViewTapped))
+    }
+    
+    self.dimmedView.do {
+      $0.backgroundColor = .darkGray.withAlphaComponent(0.7)
+      $0.addGestureRecognizer(self.dimmedTap)
+      $0.isUserInteractionEnabled = true
+    }
+  }
+  
+  @objc private func dimmedViewTapped() {
+    self.hideBottomSheetAndGoBack()
+  }
+  
+  func hideBottomSheetAndGoBack() {
+    self.bottomSheetView.snp.remakeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(self.view.snp.bottom).offset(self.defaultHeight)
+      $0.top.equalTo(self.view.snp.bottom)
+    }
+    
+    UIView.animate(withDuration: 0.25,
+                   delay: 0,
+                   options: .curveEaseIn) { [weak self] in
+      self?.view.layoutIfNeeded()
+    } completion: { _ in
+      self.dismiss(animated: false)
+    }
+  }
+  
+  private func layout() {
+    self.view.addSubview(self.dimmedView)
+    self.view.addSubview(self.bottomSheetView)
+    
+    self.bottomSheetView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(self.view.snp.bottom).offset(self.defaultHeight)
+      $0.top.equalTo(self.view.snp.bottom)
+    }
+    
+    self.dimmedView.snp.makeConstraints {
+      $0.leading.trailing.top.bottom.equalToSuperview()
+    }
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    self.showBottomSheet()
+  }
+  
+  private func showBottomSheet() {
+    self.bottomSheetView.snp.remakeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(self.view.snp.bottom)
+      $0.top.equalTo(self.view.snp.bottom).inset(self.defaultHeight)
+    }
+    
+    UIView.animate(withDuration: 0.25,
+                   delay: 0,
+                   options: .curveEaseIn) { [weak self] in
+      self?.view.layoutIfNeeded()
+    }
+  }
+}

--- a/Bithumb/BithumbTests/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodViewModelTests.swift
+++ b/Bithumb/BithumbTests/Exchange/Components/PriceChangedPeriodBottomSheet/PriceChangedPeriodViewModelTests.swift
@@ -1,0 +1,105 @@
+//
+//  PriceChangedPeriodViewModelTests.swift
+//  BithumbTests
+//
+//  Created by 이영우 on 2022/01/24.
+//
+
+import XCTest
+@testable import Bithumb
+
+import Nimble
+import RxNimble
+import RxSwift
+import RxTest
+
+final class PriceChangedPeriodViewModelTests: XCTestCase {
+  
+  var sut: PriceChangedPeriodViewModel!
+  var scheduler: TestScheduler!
+  var disposeBag: DisposeBag!
+  
+  
+  // MARK: Settings
+  
+  override func setUp() {
+    self.scheduler = TestScheduler(initialClock: 0)
+    self.disposeBag = DisposeBag()
+  }
+  
+  override func tearDown() {
+    self.disposeBag = DisposeBag()
+  }
+  
+  
+  // MARK: Tests
+  
+  func test_어제_대비였을_때_24시간을_누르는_경우() throws {
+    //given
+    self.sut = PriceChangedPeriodViewModel(selectedPeriod: .yesterday)
+
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(5, IndexPath(row: 1, section: .zero))
+      ]
+    ).bind(to: self.sut.tapListView)
+      .disposed(by: self.disposeBag)
+
+    //then
+    expect(self.sut.selectedPeriod)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal(
+        [
+          .next(0, Period.yesterday),
+          .next(5, Period.twentyFourHour)
+        ]
+      ))
+  }
+  
+  func test_24시간였을_때_한_시간을_누르는_경우() throws {
+    //given
+    self.sut = PriceChangedPeriodViewModel(selectedPeriod: .twentyFourHour)
+    
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(5, IndexPath(row: 3, section: .zero))
+      ]
+    ).bind(to: self.sut.tapListView)
+      .disposed(by: self.disposeBag)
+
+    //then
+    expect(self.sut.selectedPeriod)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal(
+        [
+          .next(0, Period.twentyFourHour),
+          .next(5, Period.oneHour)
+        ]
+      ))
+  }
+  
+  func test_12시간였을_때_30분을_누르는_경우() throws {
+    //given
+    self.sut = PriceChangedPeriodViewModel(selectedPeriod: .twelveHour)
+    
+    //when
+    self.scheduler.createColdObservable(
+      [
+        .next(5, IndexPath(row: 4, section: .zero))
+      ]
+    ).bind(to: self.sut.tapListView)
+      .disposed(by: self.disposeBag)
+
+    //then
+    expect(self.sut.selectedPeriod)
+      .events(scheduler: self.scheduler, disposeBag: self.disposeBag)
+      .to(equal(
+        [
+          .next(0, Period.twelveHour),
+          .next(5, Period.thirtyMinute)
+        ]
+      ))
+  }
+}


### PR DESCRIPTION
## 배경
- #13 
- 거래소 화면에서 사용하기 위한 BottomSheet를 구현해요

## 수정 내역
- 여러 화면에서 사용할 수 있는, BottomSheet를 구현했어요
- ExchangeViewController에서 사용할 PriceChangedPeriodBottomSheet를 구현했어요
- PriceChangedPeriodViewModel을 구현하고, Unit Test를 진행했어요

## 테스트 방법
- 구동 테스트
<p>
<img src="https://user-images.githubusercontent.com/64566207/150713177-9916962f-5c40-460e-a17d-addbaf7dd080.png" width="300">
<img src="https://user-images.githubusercontent.com/64566207/150713183-e8d250b1-0bef-4ed7-bf6f-1bfb1a4301dc.png" width="240">
</p>

- 유닛 테스트

ViewModel을 앱 사용시 상황을 가정하여서 Unit Test 진행했어요
