### PR TITLE
[#20] ExchangeViewController에 각 UI 컴포넌트들을 배치하고 Cell 데이터에 따른 설정을 해요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
 		B4A8E118279BF15D00A2BFCD /* SegmentedCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E117279BF15D00A2BFCD /* SegmentedCategoryView.swift */; };
 		B4A8E11A279D286200A2BFCD /* UISegmentedControl + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E119279D286200A2BFCD /* UISegmentedControl + Ext.swift */; };
+		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		F19014D04656742DAD3CEE42 /* Pods_Bithumb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57327AFB9F622280BD99C397 /* Pods_Bithumb.framework */; };
 /* End PBXBuildFile section */
 
@@ -110,6 +111,7 @@
 		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
 		B4A8E117279BF15D00A2BFCD /* SegmentedCategoryView.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = SegmentedCategoryView.swift; sourceTree = "<group>"; tabWidth = 2; };
 		B4A8E119279D286200A2BFCD /* UISegmentedControl + Ext.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "UISegmentedControl + Ext.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3E678E6A65670DF362AEC9A /* Pods_Bithumb_BithumbUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bithumb_BithumbUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE15410D7F32C1F0DA5436F6 /* Pods-BithumbTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.release.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.release.xcconfig"; sourceTree = "<group>"; };
 		EAB7FEE542EBD52C0D4D875A /* Pods-Bithumb.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb.debug.xcconfig"; path = "Target Support Files/Pods-Bithumb/Pods-Bithumb.debug.xcconfig"; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			isa = PBXGroup;
 			children = (
 				B4A8E119279D286200A2BFCD /* UISegmentedControl + Ext.swift */,
+				C3D0EF4127A1902000A5E4BE /* String + Ext.swift */,
 				B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */,
 			);
 			path = Extensions;
@@ -679,6 +682,7 @@
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
+				C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */,
 				4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */,
 				4882FA6F279D288100A25880 /* Currency.swift in Sources */,
 				48B60E4C279FBF3B000534EC /* TickerResponse.swift in Sources */,
@@ -689,7 +693,6 @@
 				488F9E7C279BA68F0021A545 /* AllTickerResponse.swift in Sources */,
 				B4A8E11A279D286200A2BFCD /* UISegmentedControl + Ext.swift in Sources */,
 				B4A8E118279BF15D00A2BFCD /* SegmentedCategoryView.swift in Sources */,
-
 				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListView.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListView.swift
@@ -31,7 +31,7 @@ final class CoinListView: UITableView {
     self.backgroundColor = .white
     self.register(CoinListViewCell.self, forCellReuseIdentifier: "CoinListViewCell")
     self.separatorStyle = .singleLine
-    self.rowHeight = 100
+    self.rowHeight = 60
   }
   
   func bind(viewModel: CoinListViewModel) {

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCell.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCell.swift
@@ -105,13 +105,12 @@ final class CoinListViewCell: UITableViewCell {
     }
   }
   
-  // TBD: "%" 표시 등 구체적인 디테일은 추후 구현 예정
   func setData(with data: CoinListViewCellData) {
+    self.transactionAmountLabel.text = data.transactionAmountText()
     self.coinTitleLabel.text = data.coinName
     self.tickerLabel.text = data.ticker
-    self.currentPriceLabel.text = data.currentPrice
-    self.priceChangedRatioLabel.text = data.priceChangedRatio
-    self.priceDifferenceLabel.text = data.priceDifference
-    self.transactionAmountLabel.text = data.transactionAmount
+    self.currentPriceLabel.attributedText = data.currentPriceText()
+    self.priceDifferenceLabel.attributedText = data.priceDifferenceText()
+    self.priceChangedRatioLabel.attributedText = data.priceChangedRatioText()
   }
 }

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -55,7 +55,7 @@ extension CoinListViewCellData {
     guard let transactionAmount = Double(self.transactionAmount) else {
       return nil
     }
-    let millionUnitNumber = Int(round(transactionAmount / 1000000))
+    let millionUnitNumber = Int(floor(transactionAmount / 1000000))
     
     guard var millionUnitText = String(millionUnitNumber).convertToDecimalText() else {
       return nil

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -29,12 +29,14 @@ extension CoinListViewCellData {
   
   func priceDifferenceText() -> NSAttributedString? {
     guard let priceDifference = Double(self.priceDifference),
-          let convertedString = self.priceDifference.convertToDecimalText() else {
-        return nil
-      }
-      
+          let convertedString = String(abs(priceDifference)).convertToDecimalText() else {
+            return nil
+          }
+    
+    let sign = self.sign(about: priceDifference)
     let color = UIColor.tickerColor(with: priceDifference)
-      return convertedString.convertToAttributedString(with: color)
+    let priceDifferenceText = sign + convertedString
+    return priceDifferenceText.convertToAttributedString(with: color)
   }
   
   func priceChangedRatioText() -> NSAttributedString? {
@@ -54,7 +56,7 @@ extension CoinListViewCellData {
       return nil
     }
     let millionUnitNumber = Int(round(transactionAmount / 1000000))
-
+    
     guard var millionUnitText = String(millionUnitNumber).convertToDecimalText() else {
       return nil
     }

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -65,7 +65,7 @@ extension CoinListViewCellData {
     return millionUnitText
   }
   
-  private func sign(about number: Double) -> String {
+  private func sign(of number: Double) -> String {
     if number == .zero {
       return ""
     } else if number > .zero {

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -5,7 +5,7 @@
 //  Created by Seungjin Baek on 2022/01/24.
 //
 
-import Foundation
+import UIKit
 
 struct CoinListViewCellData: Equatable {
   let coinName: String
@@ -15,3 +15,54 @@ struct CoinListViewCellData: Equatable {
   let priceDifference: String
   let transactionAmount: String
 }
+
+extension CoinListViewCellData {
+  func currentPriceText() -> NSAttributedString? {
+    guard let priceDifference = Double(self.priceDifference) else {
+      return nil
+    }
+    
+    let priceText = self.currentPrice.convertToDecimalText()
+    let color = UIColor.tickerColor(with: priceDifference)
+    return priceText?.convertToAttributedString(with: color)
+  }
+  
+  func priceDifferenceText() -> NSAttributedString? {
+    guard let priceDifference = Double(self.priceDifference),
+          let convertedString = self.priceDifference.convertToDecimalText() else {
+        return nil
+      }
+      
+    let color = UIColor.tickerColor(with: priceDifference)
+      return convertedString.convertToAttributedString(with: color)
+  }
+  
+  func priceChangedRatioText() -> NSAttributedString? {
+    guard var priceChangedRatio = Double(self.priceChangedRatio) else {
+      return nil
+    }
+    
+    var percentageText = ""
+    priceChangedRatio = round(priceChangedRatio * 100) / 100
+    percentageText = priceChangedRatio >= 0 ? "+" : ""
+    percentageText.append(String(priceChangedRatio) + "%")
+    
+    let color = UIColor.tickerColor(with: priceChangedRatio)
+    return percentageText.convertToAttributedString(with: color)
+  }
+  
+  func transactionAmountText() -> String? {
+    guard let transactionAmount = Double(self.transactionAmount) else {
+      return nil
+    }
+    let millionUnitNumber = Int(round(transactionAmount / 1000000))
+
+    guard var millionUnitText = String(millionUnitNumber).convertToDecimalText() else {
+      return nil
+    }
+    
+    millionUnitText += "백만"
+    return millionUnitText
+  }
+}
+

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -38,16 +38,14 @@ extension CoinListViewCellData {
   }
   
   func priceChangedRatioText() -> NSAttributedString? {
-    guard var priceChangedRatio = Double(self.priceChangedRatio) else {
+    guard let priceChangedRatio = Double(self.priceChangedRatio) else {
       return nil
     }
     
-    var percentageText = ""
-    priceChangedRatio = round(priceChangedRatio * 100) / 100
-    percentageText = priceChangedRatio >= 0 ? "+" : ""
-    percentageText.append(String(priceChangedRatio) + "%")
-    
+    let sign = self.sign(about: priceChangedRatio)
     let color = UIColor.tickerColor(with: priceChangedRatio)
+    let slicedPriceChangedRatio = abs(floor(priceChangedRatio * 100) / 100)
+    let percentageText = sign + String(slicedPriceChangedRatio) + "%"
     return percentageText.convertToAttributedString(with: color)
   }
   
@@ -63,6 +61,16 @@ extension CoinListViewCellData {
     
     millionUnitText += "백만"
     return millionUnitText
+  }
+  
+  private func sign(about number: Double) -> String {
+    if number == .zero {
+      return ""
+    } else if number > .zero {
+      return "+"
+    } else {
+      return "-"
+    }
   }
 }
 

--- a/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
@@ -22,11 +22,12 @@ final class ExchangeViewController: UIViewController {
   // MARK: Initializers
   
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    let categoryItems = ["원화", "BTC", "관심"]
+    self.segmentedCategoryView = SegmentedCategoryView(items: categoryItems, fontSize: 14)
     self.networkManager = NetworkManager()
     self.exchangeUseCase = ExchangeUseCase(network: self.networkManager)
     self.exchangeViewModel = ExchangeViewModel(useCase: self.exchangeUseCase)
     self.exchangeSearchBar = ExchangeSearchBar()
-    self.segmentedCategoryView = SegmentedCategoryView(items: ["원화", "BTC", "관심"], fontSize: 14)
     self.coinListView = CoinListView()
     
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)

--- a/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
+++ b/Bithumb/Bithumb/Exchange/ExchangeViewController.swift
@@ -12,6 +12,7 @@ final class ExchangeViewController: UIViewController {
   // MARK: Properties
   
   let coinListView: CoinListView
+  let segmentedCategoryView: SegmentedCategoryView
   let exchangeSearchBar: ExchangeSearchBar
   let exchangeViewModel: ExchangeViewModelLogic
   let exchangeUseCase: ExchangeUseCaseLogic
@@ -25,6 +26,7 @@ final class ExchangeViewController: UIViewController {
     self.exchangeUseCase = ExchangeUseCase(network: self.networkManager)
     self.exchangeViewModel = ExchangeViewModel(useCase: self.exchangeUseCase)
     self.exchangeSearchBar = ExchangeSearchBar()
+    self.segmentedCategoryView = SegmentedCategoryView(items: ["원화", "BTC", "관심"], fontSize: 14)
     self.coinListView = CoinListView()
     
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -50,19 +52,23 @@ final class ExchangeViewController: UIViewController {
     self.coinListView.bind(viewModel: self.exchangeViewModel.coinListViewModel)
   }
   
-  //TBD: UI 재조정 필요
   private func layout() {
-    [self.exchangeSearchBar, self.coinListView].forEach { self.view.addSubview($0) }
+    self.setUpNavigationBar()
     
-    self.exchangeSearchBar.snp.makeConstraints {
-      $0.top.equalTo(view.safeAreaLayoutGuide)
-      $0.leading.trailing.equalToSuperview()
+    [self.segmentedCategoryView, self.coinListView].forEach { self.view.addSubview($0) }
+    
+    self.segmentedCategoryView.snp.makeConstraints {
+      $0.leading.top.equalTo(self.view.safeAreaLayoutGuide).inset(10)
     }
     
     self.coinListView.snp.makeConstraints {
-      $0.top.equalTo(exchangeSearchBar.snp.bottom)
+      $0.top.equalTo(self.segmentedCategoryView.snp.bottom).offset(10)
       $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalToSuperview().inset(100)
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
     }
+  }
+  
+  private func setUpNavigationBar() {
+    self.navigationItem.titleView = exchangeSearchBar
   }
 }

--- a/Bithumb/Bithumb/Resources/Extensions/String + Ext.swift
+++ b/Bithumb/Bithumb/Resources/Extensions/String + Ext.swift
@@ -1,0 +1,26 @@
+//
+//  String + Ext.swift
+//  Bithumb
+//
+//  Created by 이영우 on 2022/01/26.
+//
+
+import UIKit
+
+extension String {
+  func convertToDecimalText() -> String? {
+    let numberFormatter = NumberFormatter()
+    numberFormatter.numberStyle = .decimal
+    
+    guard let number = Double(self),
+          let convertedText = numberFormatter.string(for: number) else {
+      return nil
+    }
+    
+    return convertedText
+  }
+  
+  func convertToAttributedString(with color: UIColor) -> NSAttributedString {
+    return  NSAttributedString(string: self, attributes: [.foregroundColor : color])
+  }
+}

--- a/Bithumb/Bithumb/Resources/Extensions/UIColor + Ext.swift
+++ b/Bithumb/Bithumb/Resources/Extensions/UIColor + Ext.swift
@@ -8,19 +8,29 @@
 import UIKit
 
 extension UIColor {
-    func image(_ size: CGSize) -> UIImage {
-        return UIGraphicsImageRenderer(size: size).image { rendererContext in
-            self.setFill()
-            rendererContext.fill(CGRect(origin: .zero, size: size))
-        }
+  func image(_ size: CGSize) -> UIImage {
+    return UIGraphicsImageRenderer(size: size).image { rendererContext in
+      self.setFill()
+      rendererContext.fill(CGRect(origin: .zero, size: size))
     }
-    
-    static var bithumb: UIColor {
-        return UIColor(
-            red: 227/255,
-            green: 129/255,
-            blue: 30/255,
-            alpha: 1
-          )
+  }
+  
+  static var bithumb: UIColor {
+    return UIColor(
+      red: 227/255,
+      green: 129/255,
+      blue: 30/255,
+      alpha: 1
+    )
+  }
+  
+  static func tickerColor<T: BinaryFloatingPoint>(with number: T) -> UIColor {
+    if number > 0 {
+      return .red
+    } else if number == 0 {
+      return .black
+    } else {
+      return .blue
     }
+  }
 }


### PR DESCRIPTION
## 배경

- #20 
- 각 UI 컴포넌트들을 배치하고, CoinListViewCell의 setData를 자세하게 설정해요

## 수정 내역
- ExchangeSearchBar, ExchangeCategoryView, CoinListView를 배치했어요
- Cell setData 메서드를 실제 기획에 맞게 변경했어요

   - CoinListViewCellData에 변경 적용된 텍스트 생성하는 메소드 생성
   - String Extension 을 통해서 숫자 세 자리 마다 (,) 추가할 수 있는 메서드 추가
   - String Extension 을 통해서 색이 있는 NSAttributedString 생성하는 메서드 추가
   - UIColor Extension 을 통해서 가격 변동에 따른 색깔 판별 메서드 추가

## 테스트 방법

구동 테스트

 <img src="https://user-images.githubusercontent.com/64566207/151195634-6570e732-4ecf-4886-a2cd-e86734b4d7f5.png" width="300">


## 리뷰 노트

- 현재 모든 기기에서 시뮬레이터를 실행해봤어요. iPhone13 mini의 경우 아래와 같이 그래픽이 깨지는 경우가 발생해요.

<img src="https://user-images.githubusercontent.com/64566207/151197272-73f3d9b1-4708-4915-a84e-6f7ede46a868.png" width="350">

<img src="https://user-images.githubusercontent.com/64566207/151197264-9e098c10-8d43-418e-b114-7a6606d55cdf.png" width="350">


