### PR TITLE
[#28] 이전 CoinListCellData sign 메서드 네이밍 변경을 호출부에 적용해요

### DIFF
--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewCellData.swift
@@ -33,7 +33,7 @@ extension CoinListViewCellData {
             return nil
           }
     
-    let sign = self.sign(about: priceDifference)
+    let sign = self.sign(of: priceDifference)
     let color = UIColor.tickerColor(with: priceDifference)
     let priceDifferenceText = sign + convertedString
     return priceDifferenceText.convertToAttributedString(with: color)
@@ -44,7 +44,7 @@ extension CoinListViewCellData {
       return nil
     }
     
-    let sign = self.sign(about: priceChangedRatio)
+    let sign = self.sign(of: priceChangedRatio)
     let color = UIColor.tickerColor(with: priceChangedRatio)
     let slicedPriceChangedRatio = abs(floor(priceChangedRatio * 100) / 100)
     let percentageText = sign + String(slicedPriceChangedRatio) + "%"


### PR DESCRIPTION
## 작업 배경

- #20 
- 위 작업에서 CoinListCellData sign 메서드 네이밍 변경을 제대로 적용하지 못하여 컴파일 에러가 발생하고 있어요

## 작업 내용

- sign 메서드를 호출하는 `priceDifferenceText`, `priceChangedRatioText` 에서 매개변수 이름을 about에서 of로 변경해줬어요