### PR TITLE
[#33] WebSocket 통신을 위한 기반 작업을 해요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		489FB622279C29D20078AEE1 /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FB621279C29D20078AEE1 /* NetworkManagerTests.swift */; };
 		489FB624279C43F10078AEE1 /* BithumbNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FB623279C43F10078AEE1 /* BithumbNetworkError.swift */; };
 		48A49ECF27A9772000DF5124 /* SocketTickerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */; };
+		48AD306F27A974F100278D7A /* WebSocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AD306E27A974F000278D7A /* WebSocketManager.swift */; };
 		48B60E48279F923A000534EC /* ExchangeUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E47279F923A000534EC /* ExchangeUseCaseTests.swift */; };
 		48B60E4C279FBF3B000534EC /* TickerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E4B279FBF3B000534EC /* TickerResponse.swift */; };
 		48B60E5227A035F2000534EC /* ExchangeUseCaseSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E5127A035F2000534EC /* ExchangeUseCaseSpy.swift */; };
@@ -111,6 +112,7 @@
 		489FB621279C29D20078AEE1 /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
 		489FB623279C43F10078AEE1 /* BithumbNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbNetworkError.swift; sourceTree = "<group>"; };
 		48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTickerResponse.swift; sourceTree = "<group>"; };
+		48AD306E27A974F000278D7A /* WebSocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketManager.swift; sourceTree = "<group>"; };
 		48B60E47279F923A000534EC /* ExchangeUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCaseTests.swift; sourceTree = "<group>"; };
 		48B60E4B279FBF3B000534EC /* TickerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerResponse.swift; sourceTree = "<group>"; };
 		48B60E5127A035F2000534EC /* ExchangeUseCaseSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCaseSpy.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				489FB623279C43F10078AEE1 /* BithumbNetworkError.swift */,
 				48256CE62799732E008F2AD1 /* NetworkManager.swift */,
 				489FB61D279BF10B0078AEE1 /* NetworkRequestRouter.swift */,
+				48AD306E27A974F000278D7A /* WebSocketManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -752,6 +755,7 @@
 				488F9E7C279BA68F0021A545 /* AllTickerResponse.swift in Sources */,
 				B4A8E11A279D286200A2BFCD /* UISegmentedControl + Ext.swift in Sources */,
 				B4A8E118279BF15D00A2BFCD /* SegmentedCategoryView.swift in Sources */,
+				48AD306F27A974F100278D7A /* WebSocketManager.swift in Sources */,
 				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		489FB61E279BF10B0078AEE1 /* NetworkRequestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FB61D279BF10B0078AEE1 /* NetworkRequestRouter.swift */; };
 		489FB622279C29D20078AEE1 /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FB621279C29D20078AEE1 /* NetworkManagerTests.swift */; };
 		489FB624279C43F10078AEE1 /* BithumbNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FB623279C43F10078AEE1 /* BithumbNetworkError.swift */; };
+		48A49ECF27A9772000DF5124 /* SocketTickerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */; };
 		48B60E48279F923A000534EC /* ExchangeUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E47279F923A000534EC /* ExchangeUseCaseTests.swift */; };
 		48B60E4C279FBF3B000534EC /* TickerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E4B279FBF3B000534EC /* TickerResponse.swift */; };
 		48B60E5227A035F2000534EC /* ExchangeUseCaseSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B60E5127A035F2000534EC /* ExchangeUseCaseSpy.swift */; };
@@ -109,6 +110,7 @@
 		489FB61D279BF10B0078AEE1 /* NetworkRequestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestRouter.swift; sourceTree = "<group>"; };
 		489FB621279C29D20078AEE1 /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
 		489FB623279C43F10078AEE1 /* BithumbNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbNetworkError.swift; sourceTree = "<group>"; };
+		48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTickerResponse.swift; sourceTree = "<group>"; };
 		48B60E47279F923A000534EC /* ExchangeUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCaseTests.swift; sourceTree = "<group>"; };
 		48B60E4B279FBF3B000534EC /* TickerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerResponse.swift; sourceTree = "<group>"; };
 		48B60E5127A035F2000534EC /* ExchangeUseCaseSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCaseSpy.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				488F9E7B279BA68E0021A545 /* AllTickerResponse.swift */,
 				4882FA6E279D288100A25880 /* Currency.swift */,
 				48B60E4B279FBF3B000534EC /* TickerResponse.swift */,
+				48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -728,6 +731,7 @@
 				4865371D27A69DB300BEBBB3 /* SegmentedCategoryViewModel.swift in Sources */,
 				4885375C27A3D90E00BE00FD /* CurrentAssetCoordinator.swift in Sources */,
 				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,
+				48A49ECF27A9772000DF5124 /* SocketTickerResponse.swift in Sources */,
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				489FB624279C43F10078AEE1 /* BithumbNetworkError.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,

--- a/Bithumb/Bithumb/Entity/SocketTickerResponse.swift
+++ b/Bithumb/Bithumb/Entity/SocketTickerResponse.swift
@@ -1,0 +1,56 @@
+//
+//  SocketTickerResponse.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/02/01.
+//
+
+import Foundation
+
+/**
+{
+  "type" : "ticker",
+  "content" : {
+    "symbol" : "BTC_KRW",      // 통화코드
+    "tickType" : "24H",          // 변동 기준시간- 30M, 1H, 12H, 24H, MID
+    "date" : "20200129",        // 일자
+    "time" : "121844",          // 시간
+    "openPrice" : "2302",        // 시가
+    "closePrice" : "2317",        // 종가
+    "lowPrice" : "2272",        // 저가
+    "highPrice" : "2344",        // 고가
+    "value" : "2831915078.07065789",  // 누적거래금액
+    "volume" : "1222314.51355788",  // 누적거래량
+    "sellVolume" : "760129.34079004",  // 매도누적거래량
+    "buyVolume" : "462185.17276784",  // 매수누적거래량
+    "prevClosePrice" : "2326",      // 전일종가
+    "chgRate" : "0.65",          // 변동률
+    "chgAmt" : "15",          // 변동금액
+    "volumePower" : "60.80"      // 체결강도
+  }
+}
+*/
+
+struct SocketTickerResponse: Decodable {
+  let type: String
+  let content: SocketTickerData
+}
+
+struct SocketTickerData: Decodable {
+  let tickType: String
+  let date: String
+  let time: String
+  let openPrice: String
+  let closePrice: String
+  let lowPrice: String
+  let highPrice: String
+  let value: String
+  let volume: String
+  let sellVolume: String
+  let buyVolume: String
+  let prevClosePrice: String
+  let chgRate: String
+  let chgAmt: String
+  let volumePower: String
+  let symbol: String
+}

--- a/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/CoinList/CoinListViewModel.swift
@@ -7,20 +7,72 @@
 
 import RxCocoa
 import RxSwift
+import Starscream
 
 protocol CoinListViewModelLogic {
   var coinListCellData: PublishSubject<[CoinListViewCellData]> { get }
   var cellData: Driver<[CoinListViewCellData]> { get }
   var selectedOrderCurrency: PublishSubject<OrderCurrency> { get }
+  var socketText: PublishSubject<String> { get }
+  var updatedTickerData: Observable<SocketTickerData> { get }
 }
 
 final class CoinListViewModel: CoinListViewModelLogic {
   let coinListCellData = PublishSubject<[CoinListViewCellData]>()
   let cellData: Driver<[CoinListViewCellData]>
   let selectedOrderCurrency = PublishSubject<OrderCurrency>()
+  let socketText = PublishSubject<String>()
+  let updatedTickerData: Observable<SocketTickerData>
+  private let disposeBag = DisposeBag()
 
   init() {
     self.cellData = self.coinListCellData
       .asDriver(onErrorJustReturn: [])
+
+    self.updatedTickerData = self.socketText
+      .map {
+        return $0.replacingOccurrences(of: "\\", with: "").data(using: .utf8)
+      }.filter { $0 != nil }
+      .map {
+        return try? JSONDecoder().decode(SocketTickerResponse.self, from: $0!)
+      }.filter { $0 != nil }
+      .map {
+        $0!.content
+      }
+
+    WebSocketManager.shared.socket?.delegate = self
+  }
+}
+
+
+// MARK: - WebSocket Delegate Logic
+
+extension CoinListViewModel: WebSocketDelegate {
+  func didReceive(event: WebSocketEvent, client: WebSocket) {
+    switch event {
+    case .connected(let headers):
+      client.write(string: "이름")
+      print("websocket is connected: \(headers)")
+    case .disconnected(let reason, let code):
+      print("websocket is disconnected: \(reason) with code: \(code)")
+    case .text(let text):
+      Observable.just(text)
+        .bind(to: self.socketText)
+        .disposed(by: self.disposeBag)
+    case .binary(let data):
+      print("Received data: \(data.count)")
+    case .ping(_):
+      break
+    case .pong(_):
+      break
+    case .viabilityChanged(_):
+      break
+    case .reconnectSuggested(_):
+      break
+    case .cancelled:
+      print("websocket is canceled")
+    case .error(let error):
+      print("websocket is error = \(error!)")
+    }
   }
 }

--- a/Bithumb/Bithumb/Network/WebSocketManager.swift
+++ b/Bithumb/Bithumb/Network/WebSocketManager.swift
@@ -1,0 +1,63 @@
+//
+//  SocketManager.swift
+//  Bithumb
+//
+//  Created by Seungjin Baek on 2022/02/01.
+//
+
+import Foundation
+
+import Starscream
+
+// MARK: - Web Socket Type
+
+enum SocketType {
+  case ticker
+  case orderbookdepth
+  case transaction
+
+  var message: String {
+    switch self {
+    case .ticker:
+      return "ticker"
+    case .orderbookdepth:
+      return "orderbookdepth"
+    case .transaction:
+      return "transaction"
+    }
+  }
+}
+
+
+// MARK: - Web Socket Manager
+
+final class WebSocketManager {
+  static let shared = WebSocketManager()
+
+  var socket: WebSocket?
+  private let baseURL = "wss://pubwss.bithumb.com/pub/ws"
+
+  init() {
+    self.setUpWebSocket()
+  }
+
+  private func setUpWebSocket() {
+    guard let request = self.setUpRequest() else { return }
+
+    self.socket = WebSocket(request: request)
+    socket?.connect()
+  }
+
+  private func setUpRequest() -> URLRequest? {
+    guard let url = URL(string: self.baseURL) else { return nil }
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 30
+    return request
+  }
+
+  // TODO: symbols, tickType은 요소 사이에 \", \" 를 넣어야됨
+  func sendMessage(socketType: SocketType, symbols: String, tickType: String) {
+    let message = "{\"type\":\(socketType.message), \"symbols\": [\"\(symbols)\"], \"tickTypes\": [\"\(tickType)\"]}"
+    socket?.write(string: message)
+  }
+}

--- a/Bithumb/Podfile
+++ b/Bithumb/Podfile
@@ -10,6 +10,7 @@ target 'Bithumb' do
   pod 'Then'
   pod 'SnapKit', '~> 5.0.0'
   pod 'Kingfisher', '~> 7.0'
+  pod 'Starscream', '~> 4.0.0'
 
   # Pods for Bithumb
 

--- a/Bithumb/Podfile.lock
+++ b/Bithumb/Podfile.lock
@@ -22,6 +22,7 @@ PODS:
   - RxTest (6.5.0):
     - RxSwift (= 6.5.0)
   - SnapKit (5.0.1)
+  - Starscream (4.0.4)
   - Then (2.7.0)
 
 DEPENDENCIES:
@@ -34,6 +35,7 @@ DEPENDENCIES:
   - RxSwift (= 6.5.0)
   - RxTest (= 6.5.0)
   - SnapKit (~> 5.0.0)
+  - Starscream (~> 4.0.0)
   - Then
 
 SPEC REPOS:
@@ -48,6 +50,7 @@ SPEC REPOS:
     - RxSwift
     - RxTest
     - SnapKit
+    - Starscream
     - Then
 
 SPEC CHECKSUMS:
@@ -61,8 +64,9 @@ SPEC CHECKSUMS:
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
   RxTest: eb2d23adefc5a5ebf5779c7792fa3edfe6ebcc17
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: dee262d9c8160fbfcd261dd9aa04e74a57478bbb
+PODFILE CHECKSUM: e532a1c09655b30ae185d1d2eaf832b6151674b1
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 배경
- #33 
- WebSocket 통신을 위한 기반 작업을 해요

## 수정 내역
- WebSocketManager를 구현했어요
- Socket 통신을 통해 받아올 Entity 타입을 구현했어요
- CoinListViewModel에 Delegate를 채택하고 데이터 전처리 기능을 구현했어요

## 테스트 방법
- 구동 테스트

## 리뷰 노트
- Delegate 구현 위치에 대해 고민했어요. ViewController보다는 ViewModel이 적합하다고 판단했어요.
- Rx용 StarScream이 있지만 이번 PR에서는 기본 StarScream으로 구현을 하다보니 Delegate 패턴을 사용하게 되었어요.