### PR TITLE
[#22] Search 검색 기능을 확장시켜요

### DIFF
--- a/Bithumb/Bithumb.xcodeproj/project.pbxproj
+++ b/Bithumb/Bithumb.xcodeproj/project.pbxproj
@@ -79,10 +79,10 @@
 		114D3A1E134DE0667AC5648F /* Pods-Bithumb-BithumbUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bithumb-BithumbUITests.release.xcconfig"; path = "Target Support Files/Pods-Bithumb-BithumbUITests/Pods-Bithumb-BithumbUITests.release.xcconfig"; sourceTree = "<group>"; };
 		26EF170BEFCCD8D7B5FAADDC /* Pods_BithumbTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BithumbTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41725A19228DD05069A43D6B /* Pods-BithumbTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BithumbTests.debug.xcconfig"; path = "Target Support Files/Pods-BithumbTests/Pods-BithumbTests.debug.xcconfig"; sourceTree = "<group>"; };
-		48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; };
+		48256CD72799722E008F2AD1 /* ExchangeViewModel.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; tabWidth = 2; };
 		48256CD927997246008F2AD1 /* ExchangeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUseCase.swift; sourceTree = "<group>"; };
 		48256CDB27997267008F2AD1 /* ExchangeSearchBar.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBar.swift; sourceTree = "<group>"; tabWidth = 2; };
-		48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModel.swift; sourceTree = "<group>"; };
+		48256CDD2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ExchangeSearchBarViewModel.swift; sourceTree = "<group>"; tabWidth = 2; };
 		48256CDF2799728C008F2AD1 /* CoinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListView.swift; sourceTree = "<group>"; };
 		48256CE127997298008F2AD1 /* CoinListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewModel.swift; sourceTree = "<group>"; };
 		48256CE3279972AA008F2AD1 /* CoinListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListViewCell.swift; sourceTree = "<group>"; };
@@ -94,7 +94,7 @@
 		4881F42F2797A22200472C90 /* CurrentAssetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAssetViewController.swift; sourceTree = "<group>"; };
 		4881F4332797A29900472C90 /* TransactionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewController.swift; sourceTree = "<group>"; };
 		4881F4352797A2B800472C90 /* MoreOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionViewController.swift; sourceTree = "<group>"; };
-		4882FA6E279D288100A25880 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
+		4882FA6E279D288100A25880 /* Currency.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; tabWidth = 2; };
 		4885375327A38EA300BE00FD /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		4885375527A3CFF800BE00FD /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		4885375727A3D1F500BE00FD /* ExchangeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeCoordinator.swift; sourceTree = "<group>"; };

--- a/Bithumb/Bithumb/Entity/Currency.swift
+++ b/Bithumb/Bithumb/Entity/Currency.swift
@@ -594,4 +594,16 @@ enum OrderCurrency: String, CaseIterable {
     }
     return .all
   }
+    
+  static func filteredItems(with name: String) -> [OrderCurrency : String] {
+    var currencies: [OrderCurrency : String] = [:]
+    for orderCurrency in OrderCurrency.allCases {
+      if orderCurrency.rawValue.contains(name) {
+        currencies[orderCurrency] = orderCurrency.rawValue
+      } else if name == "" {
+        currencies[orderCurrency] = orderCurrency.rawValue
+      }
+    }
+    return currencies
+  }
 }

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift
@@ -78,7 +78,7 @@ final class ExchangeSearchBar: UISearchBar {
   }
 
   func bind(viewModel: ExchangeSearchBarViewModelLogic) {
-    self.rx.text
+    self.rx.text.orEmpty
       .bind(to: viewModel.inputText)
       .disposed(by: self.disposeBag)
     

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
@@ -9,28 +9,27 @@ import RxCocoa
 import RxSwift
 
 protocol ExchangeSearchBarViewModelLogic {
-  var inputText: PublishRelay<String?> { get }
+  var inputText: PublishRelay<String> { get }
   var searchButtonTapped: PublishRelay<Void> { get }
-  var orderCurrencyToSearch: Observable<OrderCurrency> { get }
+  var orderCurrenciesToSearch: Observable<[OrderCurrency : String]> { get }
 }
 
 final class ExchangeSearchBarViewModel: ExchangeSearchBarViewModelLogic {
   
   // MARK: Properties
   
-  let inputText = PublishRelay<String?>()
+  let inputText = PublishRelay<String>()
   let searchButtonTapped = PublishRelay<Void>()
-  let orderCurrencyToSearch: Observable<OrderCurrency>
+  let orderCurrenciesToSearch: Observable<[OrderCurrency : String]>
 
 
   // MARK: Initializers
   
   init() {
-    self.orderCurrencyToSearch = self.searchButtonTapped
-      .withLatestFrom(self.inputText) { $1 ?? "ALL" }
-      .map {
-        return OrderCurrency.search(with: $0)
-      }
-      .distinctUntilChanged()
+    self.orderCurrenciesToSearch = self.inputText
+    .map {
+      return OrderCurrency.filteredItems(with: $0)
+    }
+    .distinctUntilChanged()
   }
 }

--- a/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
+++ b/Bithumb/Bithumb/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift
@@ -28,7 +28,7 @@ final class ExchangeSearchBarViewModel: ExchangeSearchBarViewModelLogic {
   init() {
     self.orderCurrenciesToSearch = self.inputText
     .map {
-      return OrderCurrency.filteredItems(with: $0)
+      return OrderCurrency.filteredItems(with: $0.uppercased())
     }
     .distinctUntilChanged()
   }


### PR DESCRIPTION
## 배경
- #22 
- SearchBar에 입력된 결과를 실시간 반영하고 소문자도 인식하도록 해요

## 수정내역
- SearchBar에 입력된 결과가 수정될때마다 ExchangeSearchBarViewModel에 데이터를 전달하도록 구현했어요
- ExchangeSearchBarViewModel에서 전달받은 데이터를 통해 필터링할 때 사용될 Dictionary를 ViewModel에게 전달하도록 구현했어요
- ExchangeViewModel에서 전달받은 Dictionary를 통해 네트워킹을 통해 받아온 데이터를 필터링해서 CoinListViewModel에 전달해요

## 테스트 방법
- 구동 테스트
![화면 기록 2022-02-02 오전 11 49 08](https://user-images.githubusercontent.com/56648865/152085837-19160b12-c075-4ff3-a451-896679b1145f.gif)

## 리뷰 노트
- Currency에 filteredItem 메서드 로직을 수정해야할 필요성을 느꼈어요
- 한글입력에 대한 검색기능을 추가해야해요 이번 PR에서 추가해서 commit할 예정이에요